### PR TITLE
Make Typical Indentation Behavior Triggerable by a Variable

### DIFF
--- a/ceylon-mode.el
+++ b/ceylon-mode.el
@@ -32,6 +32,15 @@
 
 ;;; Code:
 
+(defgroup ceylon nil
+  "A coding mode for the Ceylon JVM language."
+
+  :group   'extensions
+  :group   'convenience
+  :version "0.2"
+  :prefix  "ceylon-"
+  :link    '(url-link :tag "Github"
+                           "https://github.com/lucaswerkmeister/ceylon-mode"))
 (defconst ceylon-font-lock-string
   (list
    ;; highlighting strings with regexes, because Emacs' proper model (syntax table) isn't flexible enough to suppport string templates or verbatim strings
@@ -95,8 +104,13 @@
     st)
   "Syntax table for `ceylon-mode'.")
 
-(set-default 'tab-width                     4)
-(set-default 'ceylon-return-point-on-indent nil)
+(set-default 'tab-width                    4)
+(defcustom   ceylon-return-point-on-indent t
+  "Boolean to set indentation behavior.
+
+A nil value moves the cursor to the end of the indentation upon indent.
+A t   value keeps indentation behavior as is standard in most emacs modes."
+  :type 'boolean)
 (defun ceylon-indent-line ()
   "Indent current line as Ceylon code."
   (let* ((cur-column (and ceylon-return-point-on-indent
@@ -105,7 +119,8 @@
 
     (if (bobp) ; beginning of buffer?
         (indent-line-to 0)
-      (let (cur-indent (old-indent (current-indentation)))
+      (let ( cur-indent
+            (old-indent (current-indentation)))
         (save-excursion
           (forward-line -1)
           (while (and (looking-at "^[ \t]*$") (not (bobp))) ; skip over blank lines

--- a/ceylon-mode.el
+++ b/ceylon-mode.el
@@ -95,35 +95,51 @@
     st)
   "Syntax table for `ceylon-mode'.")
 
-(set-default 'tab-width 4)
+(set-default 'tab-width                     4)
+(set-default 'ceylon-return-point-on-indent nil)
 (defun ceylon-indent-line ()
   "Indent current line as Ceylon code."
-  (beginning-of-line)
-  (if (bobp) ; beginning of buffer?
-      (indent-line-to 0)
-    (let (cur-indent)
-      (save-excursion
-        (forward-line -1)
-        (while (and (looking-at "^[ \t]*$") (not (bobp))) ; skip over blank lines
-          (forward-line -1))
-        (setq cur-indent (current-indentation))
-        (let* ((start (line-beginning-position))
-               (end   (line-end-position))
-               (open-parens    (how-many "(" start end))
-               (close-parens   (how-many ")" start end))
-               (open-braces    (how-many "{" start end))
-               (close-braces   (how-many "}" start end))
-               (open-brackets  (how-many "\\[" start end))
-               (close-brackets (how-many "\\]" start end))
-               (balance (- (+ open-parens open-braces open-brackets)
-                           (+ close-parens close-braces close-brackets))))
-          (if (looking-at"[ \t]*\\(}\\|)\\|]\\)")
-              (setq balance (+ balance 1)))
-          (setq cur-indent (+ cur-indent (* balance tab-width)))))
-      (if (looking-at "[ \t]*\\(}\\|)\\|]\\)")
-          (setq cur-indent (- cur-indent tab-width)))
-      (if (>= cur-indent 0)
-          (indent-line-to cur-indent)))))
+  (let* ((cur-column       (and ceylon-return-point-on-indent
+                                (current-column)))
+         (get-line-length  (lambda ()
+                             (- (progn
+                                  (end-of-line)
+                                  (current-column))
+                                (progn
+                                  (beginning-of-line)
+                                  (current-column)))))
+         (orig-line-length (funcall get-line-length)))
+    (beginning-of-line)
+
+    (if (bobp) ; beginning of buffer?
+        (indent-line-to 0)
+      (let (cur-indent)
+        (save-excursion
+          (forward-line -1)
+          (while (and (looking-at "^[ \t]*$") (not (bobp))) ; skip over blank lines
+            (forward-line -1))
+          (setq cur-indent (current-indentation))
+          (let* ((start (line-beginning-position))
+                 (end   (line-end-position))
+                 (open-parens    (how-many "(" start end))
+                 (close-parens   (how-many ")" start end))
+                 (open-braces    (how-many "{" start end))
+                 (close-braces   (how-many "}" start end))
+                 (open-brackets  (how-many "\\[" start end))
+                 (close-brackets (how-many "\\]" start end))
+                 (balance (- (+ open-parens open-braces open-brackets)
+                             (+ close-parens close-braces close-brackets))))
+            (if (looking-at"[ \t]*\\(}\\|)\\|]\\)")
+                (setq balance (+ balance 1)))
+            (setq cur-indent (+ cur-indent (* balance tab-width)))))
+        (if (looking-at "[ \t]*\\(}\\|)\\|]\\)")
+            (setq cur-indent (- cur-indent tab-width)))
+        (when (>= cur-indent 0)
+          (indent-line-to cur-indent)
+
+          (when (and cur-column (> cur-column cur-indent))
+            (move-to-column (+ cur-column (- (funcall get-line-length)
+                                             orig-line-length)))))))))
 ;; uncomment this to automatically reindent when a close-brace is typed;
 ;; however, this also sets the cursor *before* that brace, which is inconvenient,
 ;; so it's disabled for now.

--- a/ceylon-mode.el
+++ b/ceylon-mode.el
@@ -100,7 +100,7 @@
 (defun ceylon-indent-line ()
   "Indent current line as Ceylon code."
   (let* ((cur-column (and ceylon-return-point-on-indent
-			  (current-column))))
+                          (current-column))))
     (beginning-of-line)
 
     (if (bobp) ; beginning of buffer?

--- a/ceylon-mode.el
+++ b/ceylon-mode.el
@@ -99,21 +99,13 @@
 (set-default 'ceylon-return-point-on-indent nil)
 (defun ceylon-indent-line ()
   "Indent current line as Ceylon code."
-  (let* ((cur-column       (and ceylon-return-point-on-indent
-                                (current-column)))
-         (get-line-length  (lambda ()
-                             (- (progn
-                                  (end-of-line)
-                                  (current-column))
-                                (progn
-                                  (beginning-of-line)
-                                  (current-column)))))
-         (orig-line-length (funcall get-line-length)))
+  (let* ((cur-column (and ceylon-return-point-on-indent
+			  (current-column))))
     (beginning-of-line)
 
     (if (bobp) ; beginning of buffer?
         (indent-line-to 0)
-      (let (cur-indent)
+      (let (cur-indent (old-indent (current-indentation)))
         (save-excursion
           (forward-line -1)
           (while (and (looking-at "^[ \t]*$") (not (bobp))) ; skip over blank lines
@@ -137,9 +129,8 @@
         (when (>= cur-indent 0)
           (indent-line-to cur-indent)
 
-          (when (and cur-column (> cur-column cur-indent))
-            (move-to-column (+ cur-column (- (funcall get-line-length)
-                                             orig-line-length)))))))))
+          (when (and cur-column (> cur-column old-indent))
+            (move-to-column (+ cur-column (- cur-indent old-indent)))))))))
 ;; uncomment this to automatically reindent when a close-brace is typed;
 ;; however, this also sets the cursor *before* that brace, which is inconvenient,
 ;; so it's disabled for now.

--- a/ceylon-mode.el
+++ b/ceylon-mode.el
@@ -33,14 +33,14 @@
 ;;; Code:
 
 (defgroup ceylon nil
-  "A coding mode for the Ceylon JVM language."
+  "Major mode for editing Ceylon source code."
 
-  :group   'extensions
-  :group   'convenience
+  :group 'languages
   :version "0.2"
-  :prefix  "ceylon-"
-  :link    '(url-link :tag "Github"
-                           "https://github.com/lucaswerkmeister/ceylon-mode"))
+  :prefix "ceylon-"
+  :link '(url-link :tag "GitHub"
+                   "https://github.com/lucaswerkmeister/ceylon-mode"))
+
 (defconst ceylon-font-lock-string
   (list
    ;; highlighting strings with regexes, because Emacs' proper model (syntax table) isn't flexible enough to suppport string templates or verbatim strings
@@ -104,22 +104,29 @@
     st)
   "Syntax table for `ceylon-mode'.")
 
-(set-default 'tab-width                    4)
-(defcustom   ceylon-return-point-on-indent t
-  "Boolean to set indentation behavior.
+(set-default 'tab-width 4)
 
-A nil value moves the cursor to the end of the indentation upon indent.
-A t   value keeps indentation behavior as is standard in most emacs modes."
-  :type 'boolean)
+(defcustom ceylon-restore-point-on-indent t
+  "Whether to restore point after an indentation.
+
+If this variable is non-nil, restore point to its original position,
+adjusted for changed indentation, after an indentation operation
+completes. This matches the default behavior of most Emacs programming
+modes.
+
+If this variable is nil, leave point at the end of indentation."
+  :type '(choice (const :tag "restore original point" t)
+                 (const :tag "leave point at end of indentation" nil)))
+
 (defun ceylon-indent-line ()
   "Indent current line as Ceylon code."
-  (let* ((cur-column (and ceylon-return-point-on-indent
+  (let* ((cur-column (and ceylon-restore-point-on-indent
                           (current-column))))
     (beginning-of-line)
 
     (if (bobp) ; beginning of buffer?
         (indent-line-to 0)
-      (let ( cur-indent
+      (let (cur-indent
             (old-indent (current-indentation)))
         (save-excursion
           (forward-line -1)


### PR DESCRIPTION
I prefer the indentation behavior of emacs out of the box (namely, the one used in `java-mode`) so I created the `ceylon-return-point-on-indent` variable to be able to get both from the function.

Because I had to add a `let`, the diff. makes the changes look bigger than they are. I tried seeing if there was a way to avoid having to declare a variable (`cur-column`) so earlier when it's only used at the end but I couldn't think of anything, since you need to store it before moving the point any.

Basically, this just records – at the beginning – the column position (line 102) and then grabs the original indentation of the line (line 108) and the new indentation (line 113).

If the variable is set to true and the original column position is greater than the old indentation amount (line 132), it'll move the cursor to what would be the same character it was on after the new indentation is applied (final line of changes, 133).

If the original column position is less than the old indentation amount, do the original behavior (just `indent-line-to` and that's it) since it accomplishes the same thing as the typical indentation behavior in that circumstance, anyway.

The `ceylon-return-point-on-indent` variable defaults to `nil` to allow your current indentation behavior as default with the alternative just a switch away.