### PR TITLE
Proper Indentation for Multi-line String Literals

### DIFF
--- a/ceylon-mode.el
+++ b/ceylon-mode.el
@@ -81,8 +81,8 @@
   "Syntax highlighting for Ceylon lowercase identifiers.")
 (defconst ceylon-font-lock-uidentifier
   (list
-   '("\\<\\([[:upper:]][[:alnum:]_]*\\)\\>" . font-lock-type-face)
-   '("\\<\\(\\\\I[[:alnum:]_]*\\)\\>" . font-lock-type-face))
+   '("\\<\\([[:upper:]][[:alnum:]_]*\\)\\>\\??" . font-lock-type-face)
+   '("\\<\\(\\\\I[[:alnum:]_]*\\)\\>\\??" . font-lock-type-face))
   "Syntax highlighting for Ceylon uppercase identifiers.")
 (defconst ceylon-font-lock-all
   (append ceylon-font-lock-string ceylon-font-lock-keywords ceylon-font-lock-language-annos ceylon-font-lock-doc-annos ceylon-font-lock-lidentifier ceylon-font-lock-uidentifier)

--- a/ceylon-mode.el
+++ b/ceylon-mode.el
@@ -90,6 +90,7 @@
 (defvar ceylon-font-lock ceylon-font-lock-all ; e. g. set to ceylon-font-lock-keywords to only highlight keywords
   "Syntax highlighting for Ceylon; customizable (highlights all by default).")
 
+(set-default 'comment-start "// ")
 (defvar ceylon-mode-syntax-table
   (let ((st (make-syntax-table)))
     ;; Comments. See (elisp) Syntax Flags.


### PR DESCRIPTION
I may've found a solution to Issue #2. My reasoning: calculate the number of double quotation marks in the text preceding the mark by looking for all of those without a backslash in front of them. If the number's odd, assume we're in the middle of a String literal and indent to the same column as the double quote, without a backslash in front of it, nearest to the mark.

Unfortunately, it does mean the regexp used for the search misses any quotes that are the very first character of the entire buffer but I don't think that's likely in any circumstance that I know of for Ceylon (but I'm far less familiar with the language).